### PR TITLE
timestamp의 nanos를 mysql 서버의 precision에 맞추기 이전에 6자리까지 자릅니다.

### DIFF
--- a/src/test/java/com/mysql/cj/util/TimeUtilTest.java
+++ b/src/test/java/com/mysql/cj/util/TimeUtilTest.java
@@ -52,6 +52,8 @@ public class TimeUtilTest {
     @Test
     public void testAdjustTimestampNanosPrecision() {
         assertTrue(Timestamp.valueOf("2020-02-26 14:30:11").equals(TimeUtil.adjustNanosPrecision(Timestamp.valueOf("2020-02-26 14:30:10.999999999"), 3, true)));
+        // 6자리를 먼저 자른 뒤, 6자리로 보정하면 그대로 나온다
+        assertTrue(Timestamp.valueOf("2020-02-26 14:30:10.999999").equals(TimeUtil.adjustNanosPrecision(Timestamp.valueOf("2020-02-26 14:30:10.999999999"), 6, true)));
         assertTrue(Timestamp.valueOf("2020-02-26 14:30:10.999")
                 .equals(TimeUtil.adjustNanosPrecision(Timestamp.valueOf("2020-02-26 14:30:10.999999999"), 3, false)));
         assertTrue(Timestamp.valueOf("2020-02-26 14:30:10.778")
@@ -61,6 +63,9 @@ public class TimeUtilTest {
 
         assertTrue(LocalDateTime.of(2020, 02, 26, 14, 30, 11)
                 .equals(TimeUtil.adjustNanosPrecision(LocalDateTime.of(2020, 02, 26, 14, 30, 10, 999999999), 3, true)));
+        // 6자리를 먼저 자른 뒤, 6자리로 보정하면 그대로 나온다
+        assertTrue(LocalDateTime.of(2020, 02, 26, 14, 30, 10, 999999000)
+                .equals(TimeUtil.adjustNanosPrecision(LocalDateTime.of(2020, 02, 26, 14, 30, 10, 999999999), 6, true)));
         assertTrue(LocalDateTime.of(2020, 02, 26, 14, 30, 10, 999000000)
                 .equals(TimeUtil.adjustNanosPrecision(LocalDateTime.of(2020, 02, 26, 14, 30, 10, 999999999), 3, false)));
         assertTrue(LocalDateTime.of(2020, 02, 26, 14, 30, 10, 778000000)


### PR DESCRIPTION
https://vcnc.slack.com/archives/CQ1NUEJ9M/p1691766285766549

기존 드라이버는 6자리까지 자르고 연산해서 LocalTime.MAX 같은 상수들을 저장할 때 문제가 없었는데, aurora driver는 9자리인 상태에서 바로 연산해서 테스트가 깨지는 현상 발생

그래서 일단 기존 드라이버 구현에 맞춥니다